### PR TITLE
Make info logs as warn in transport file

### DIFF
--- a/src/io/transport.rs
+++ b/src/io/transport.rs
@@ -278,7 +278,7 @@ impl Stream for ClickhouseTransport {
         while !*this.done {
             match read_to_end(this.inner.as_mut(), cx, this.rd) {
                 Poll::Ready(Ok(0)) => {
-                    info!("[ClickhouseTransport] Stream received done signal");
+                    warn!("[ClickhouseTransport] Stream received done signal");
                     *this.done = true;
                     break;
                 }
@@ -289,7 +289,7 @@ impl Stream for ClickhouseTransport {
         }
 
         if *this.done {
-            info!("[ClickhouseTransport] Closing stream");
+            warn!("[ClickhouseTransport] Closing stream");
             return Poll::Ready(None);
         }
 
@@ -352,7 +352,10 @@ impl Stream for PacketStream {
                 },
                 PacketStreamState::Receive => {
                     let ret = match self.inner {
-                        None => None,
+                        None => {
+                            warn!("[PacketStream] Transport is None");
+                            None
+                        },
                         Some(ref mut inner) => match Pin::new(inner).poll_next(cx) {
                             Poll::Ready(Some(Ok(r))) => Some(r),
                             Poll::Ready(Some(Err(e))) => {
@@ -363,7 +366,7 @@ impl Stream for PacketStream {
                                 return Poll::Ready(Some(Err(e)));
                             }
                             Poll::Ready(None) => {
-                                info!("[PacketStream] Handling None result from transport");
+                                warn!("[PacketStream] Handling None result from transport");
                                 return Poll::Ready(None);
                             }
                             Poll::Pending => return Poll::Pending,
@@ -383,7 +386,7 @@ impl Stream for PacketStream {
                     return match self.inner.take() {
                         Some(inner) => Poll::Ready(Some(Ok(Packet::Eof(inner)))),
                         _ => {
-                            info!("[PacketStream] Transport is None");
+                            warn!("[PacketStream] Transport is None");
                             Poll::Ready(None)
                         }
                     };


### PR DESCRIPTION
Add more logs to understand the root cause of IO error seen when reading data from clickhouse